### PR TITLE
Fix typo

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -68,7 +68,7 @@ print "sys.platform:", sys.platform
                 <label id="run_info"></label>
             </div>
             <div class="checkbox float_right">
-                <label><input type="checkbox" id="wrap_output" /> warp output</label>
+                <label><input type="checkbox" id="wrap_output" /> wrap output</label>
             </div>
         </form>
     </div>


### PR DESCRIPTION
warp was fitting, but confusing until I tested it and saw that it meant wrap. Was also good to see the code actually intended it to be wrap as well.
